### PR TITLE
support USER_SELECT, ORGANIZATION_SELECT and GROUP_SELECT

### DIFF
--- a/src/main/java/org/embulk/output/kintone/KintoneColumnType.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnType.java
@@ -261,7 +261,7 @@ public enum KintoneColumnType {
 
     @Override
     public UserSelectFieldValue getFieldValue(String value, KintoneColumnOption option) {
-      throw new UnsupportedOperationException();
+      return DESERIALIZER.deserialize(value.isEmpty() ? "[]" : value, UserSelectFieldValue.class);
     }
 
     @Override
@@ -271,7 +271,7 @@ public enum KintoneColumnType {
 
     @Override
     protected List<Type> getSupportedTypes() {
-      return Collections.emptyList();
+      return Collections.singletonList(Types.JSON);
     }
   },
   ORGANIZATION_SELECT {
@@ -282,7 +282,8 @@ public enum KintoneColumnType {
 
     @Override
     public OrganizationSelectFieldValue getFieldValue(String value, KintoneColumnOption option) {
-      throw new UnsupportedOperationException();
+      return DESERIALIZER.deserialize(
+          value.isEmpty() ? "[]" : value, OrganizationSelectFieldValue.class);
     }
 
     @Override
@@ -292,7 +293,7 @@ public enum KintoneColumnType {
 
     @Override
     protected List<Type> getSupportedTypes() {
-      return Collections.emptyList();
+      return Collections.singletonList(Types.JSON);
     }
   },
   GROUP_SELECT {
@@ -303,7 +304,7 @@ public enum KintoneColumnType {
 
     @Override
     public GroupSelectFieldValue getFieldValue(String value, KintoneColumnOption option) {
-      throw new UnsupportedOperationException();
+      return DESERIALIZER.deserialize(value.isEmpty() ? "[]" : value, GroupSelectFieldValue.class);
     }
 
     @Override
@@ -313,7 +314,7 @@ public enum KintoneColumnType {
 
     @Override
     protected List<Type> getSupportedTypes() {
-      return Collections.emptyList();
+      return Collections.singletonList(Types.JSON);
     }
   },
   DATE {

--- a/src/main/java/org/embulk/output/kintone/deserializer/Deserializer.java
+++ b/src/main/java/org/embulk/output/kintone/deserializer/Deserializer.java
@@ -168,7 +168,11 @@ public class Deserializer {
 
   private User deserializeUser(JsonParser parser, DeserializationContext context) {
     JsonNode node = readTree(parser);
-    return new User(get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    if (node.isObject()) {
+      return new User(get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    } else {
+      return new User(node.asText());
+    }
   }
 
   private OrganizationSelectFieldValue deserializeOrganizationSelect(
@@ -178,8 +182,12 @@ public class Deserializer {
 
   private Organization deserializeOrganization(JsonParser parser, DeserializationContext context) {
     JsonNode node = readTree(parser);
-    return new Organization(
-        get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    if (node.isObject()) {
+      return new Organization(
+          get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    } else {
+      return new Organization(node.asText());
+    }
   }
 
   private GroupSelectFieldValue deserializeGroupSelect(
@@ -189,7 +197,11 @@ public class Deserializer {
 
   private Group deserializeGroup(JsonParser parser, DeserializationContext context) {
     JsonNode node = readTree(parser);
-    return new Group(get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    if (node.isObject()) {
+      return new Group(get(node, "name", JsonNode::asText), get(node, "code", JsonNode::asText));
+    } else {
+      return new Group(node.asText());
+    }
   }
 
   private DateFieldValue deserializeDate(JsonParser parser, DeserializationContext context) {

--- a/src/test/java/org/embulk/output/kintone/KintoneColumnTypeTest.java
+++ b/src/test/java/org/embulk/output/kintone/KintoneColumnTypeTest.java
@@ -21,20 +21,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
+import com.kintone.client.model.Group;
+import com.kintone.client.model.Organization;
+import com.kintone.client.model.User;
 import com.kintone.client.model.record.CheckBoxFieldValue;
 import com.kintone.client.model.record.DateFieldValue;
 import com.kintone.client.model.record.DateTimeFieldValue;
 import com.kintone.client.model.record.DropDownFieldValue;
+import com.kintone.client.model.record.GroupSelectFieldValue;
 import com.kintone.client.model.record.LinkFieldValue;
 import com.kintone.client.model.record.MultiLineTextFieldValue;
 import com.kintone.client.model.record.MultiSelectFieldValue;
 import com.kintone.client.model.record.NumberFieldValue;
+import com.kintone.client.model.record.OrganizationSelectFieldValue;
 import com.kintone.client.model.record.RadioButtonFieldValue;
 import com.kintone.client.model.record.RichTextFieldValue;
 import com.kintone.client.model.record.SingleLineTextFieldValue;
 import com.kintone.client.model.record.SubtableFieldValue;
 import com.kintone.client.model.record.TableRow;
 import com.kintone.client.model.record.TimeFieldValue;
+import com.kintone.client.model.record.UserSelectFieldValue;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -83,6 +89,12 @@ public class KintoneColumnTypeTest {
     assertThat(((RadioButtonFieldValue) RADIO_BUTTON.getFieldValue("", null)).getValue(), is(""));
     assertThat(((MultiSelectFieldValue) MULTI_SELECT.getFieldValue("", null)).getValues(), is(list()));
     assertThat(((DropDownFieldValue) DROP_DOWN.getFieldValue("", null)).getValue(), is(""));
+    assertThat(((UserSelectFieldValue) USER_SELECT.getFieldValue("", null)).getValues(), is(users()));
+    assertThat(((UserSelectFieldValue) USER_SELECT.getFieldValue(EMPTY, null)).getValues(), is(users()));
+    assertThat(((OrganizationSelectFieldValue) ORGANIZATION_SELECT.getFieldValue("", null)).getValues(), is(organizations()));
+    assertThat(((OrganizationSelectFieldValue) ORGANIZATION_SELECT.getFieldValue(EMPTY, null)).getValues(), is(organizations()));
+    assertThat(((GroupSelectFieldValue) GROUP_SELECT.getFieldValue("", null)).getValues(), is(groups()));
+    assertThat(((GroupSelectFieldValue) GROUP_SELECT.getFieldValue(EMPTY, null)).getValues(), is(groups()));
     assertThat(((DateFieldValue) DATE.getFieldValue(0L, null)).getValue(), is(date("1970-01-01")));
     assertThat(((DateFieldValue) DATE.getFieldValue(0.0d, null)).getValue(), is(date("1970-01-01")));
     assertThat(((DateFieldValue) DATE.getFieldValue("", null)).getValue(), is(date("1970-01-01")));
@@ -128,21 +140,15 @@ public class KintoneColumnTypeTest {
     assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue(false, null));
     assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue(0L, null));
     assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue(0.0d, null));
-    assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue("", null));
     assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue(EPOCH, null));
-    assertThrows(UnsupportedOperationException.class, () -> USER_SELECT.getFieldValue(EMPTY, null));
     assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue(false, null));
     assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue(0L, null));
     assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue(0.0d, null));
-    assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue("", null));
     assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue(EPOCH, null));
-    assertThrows(UnsupportedOperationException.class, () -> ORGANIZATION_SELECT.getFieldValue(EMPTY, null));
     assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue(false, null));
     assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue(0L, null));
     assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue(0.0d, null));
-    assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue("", null));
     assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue(EPOCH, null));
-    assertThrows(UnsupportedOperationException.class, () -> GROUP_SELECT.getFieldValue(EMPTY, null));
     assertThrows(UnsupportedOperationException.class, () -> DATE.getFieldValue(false, null));
     assertThrows(UnsupportedOperationException.class, () -> DATE.getFieldValue(EMPTY, null));
     assertThrows(UnsupportedOperationException.class, () -> TIME.getFieldValue(false, null));
@@ -178,6 +184,18 @@ public class KintoneColumnTypeTest {
 
   public static List<TableRow> rows(Long... ids) {
     return Arrays.stream(ids).map(DeserializerTest::tableRow).collect(Collectors.toList());
+  }
+
+  public static List<User> users(String... codes) {
+    return Arrays.stream(codes).map(User::new).collect(Collectors.toList());
+  }
+
+  public static List<Organization> organizations(String... codes) {
+    return Arrays.stream(codes).map(Organization::new).collect(Collectors.toList());
+  }
+
+  public static List<Group> groups(String... codes) {
+    return Arrays.stream(codes).map(Group::new).collect(Collectors.toList());
   }
 
   public static LocalDate date(CharSequence text) {

--- a/src/test/java/org/embulk/output/kintone/KintoneColumnVisitorTest.java
+++ b/src/test/java/org/embulk/output/kintone/KintoneColumnVisitorTest.java
@@ -364,6 +364,10 @@ public class KintoneColumnVisitorTest {
           assertThat(
               record.getFieldType("JSON|SUBTABLE.SINGLE_LINE_TEXT"),
               is(FieldType.SINGLE_LINE_TEXT));
+          assertThat(record.getFieldType("JSON|USER_SELECT"), is(FieldType.USER_SELECT));
+          assertThat(
+              record.getFieldType("JSON|ORGANIZATION_SELECT"), is(FieldType.ORGANIZATION_SELECT));
+          assertThat(record.getFieldType("JSON|GROUP_SELECT"), is(FieldType.GROUP_SELECT));
           assertThat(record.getSingleLineTextFieldValue("BOOLEAN|SINGLE_LINE_TEXT"), nullValue());
           assertThat(record.getNumberFieldValue("BOOLEAN"), nullValue());
           assertThat(record.getSingleLineTextFieldValue("LONG|SINGLE_LINE_TEXT"), nullValue());
@@ -415,6 +419,10 @@ public class KintoneColumnVisitorTest {
           assertThat(record.getSubtableFieldValue("JSON|SUBTABLE"), is(list()));
           assertThat(
               record.getSingleLineTextFieldValue("JSON|SUBTABLE.SINGLE_LINE_TEXT"), nullValue());
+          assertThat(record.getUserSelectFieldValue("JSON|USER_SELECT"), is(list()));
+          assertThat(
+              record.getOrganizationSelectFieldValue("JSON|ORGANIZATION_SELECT"), is(list()));
+          assertThat(record.getGroupSelectFieldValue("JSON|GROUP_SELECT"), is(list()));
           assertThat(idOrUpdateKey.getField(), is("LONG"));
           assertThat(idOrUpdateKey.getValue(), nullValue());
         });
@@ -475,6 +483,9 @@ public class KintoneColumnVisitorTest {
           assertThat(record.getFieldValue("JSON"), nullValue());
           assertThat(record.getFieldValue("JSON|SUBTABLE"), nullValue());
           assertThat(record.getFieldValue("JSON|SUBTABLE.SINGLE_LINE_TEXT"), nullValue());
+          assertThat(record.getFieldValue("JSON|USER_SELECT"), nullValue());
+          assertThat(record.getFieldValue("JSON|ORGANIZATION_SELECT"), nullValue());
+          assertThat(record.getFieldValue("JSON|GROUP_SELECT"), nullValue());
           assertThat(idOrUpdateKey.getField(), nullValue());
           assertThat(idOrUpdateKey.getValue(), nullValue());
         },
@@ -544,6 +555,10 @@ public class KintoneColumnVisitorTest {
           assertThat(record.getMultiLineTextFieldValue("JSON"), is("\"\""));
           assertThat(record.getSubtableFieldValue("JSON|SUBTABLE"), is(list()));
           assertThat(record.getFieldValue("JSON|SUBTABLE.SINGLE_LINE_TEXT"), nullValue());
+          assertThat(record.getUserSelectFieldValue("JSON|USER_SELECT"), is(list()));
+          assertThat(
+              record.getOrganizationSelectFieldValue("JSON|ORGANIZATION_SELECT"), is(list()));
+          assertThat(record.getGroupSelectFieldValue("JSON|GROUP_SELECT"), is(list()));
           assertThat(idOrUpdateKey.getField(), nullValue());
           assertThat(idOrUpdateKey.getValue(), nullValue());
         },
@@ -653,6 +668,9 @@ public class KintoneColumnVisitorTest {
         .add("JSON", Types.JSON)
         .add("JSON|SUBTABLE", Types.JSON)
         .add("JSON|SUBTABLE.SINGLE_LINE_TEXT", Types.JSON)
+        .add("JSON|USER_SELECT", Types.JSON)
+        .add("JSON|ORGANIZATION_SELECT", Types.JSON)
+        .add("JSON|GROUP_SELECT", Types.JSON)
         .build();
   }
 
@@ -709,6 +727,9 @@ public class KintoneColumnVisitorTest {
         .put(build("JSON", it -> it.setType("MULTI_LINE_TEXT")))
         .put(build("JSON|SUBTABLE", it -> it.setType("SUBTABLE")))
         .put(build("JSON|SUBTABLE.SINGLE_LINE_TEXT", it -> it.setType("SINGLE_LINE_TEXT")))
+        .put(build("JSON|USER_SELECT", it -> it.setType("USER_SELECT")))
+        .put(build("JSON|ORGANIZATION_SELECT", it -> it.setType("ORGANIZATION_SELECT")))
+        .put(build("JSON|GROUP_SELECT", it -> it.setType("GROUP_SELECT")))
         .build();
   }
 
@@ -770,6 +791,9 @@ public class KintoneColumnVisitorTest {
         .setNull("JSON")
         .setNull("JSON|SUBTABLE")
         .setNull("JSON|SUBTABLE.SINGLE_LINE_TEXT")
+        .setNull("JSON|USER_SELECT")
+        .setNull("JSON|ORGANIZATION_SELECT")
+        .setNull("JSON|GROUP_SELECT")
         .addRecord()
         .setBoolean("BOOLEAN|SINGLE_LINE_TEXT", false)
         .setBoolean("BOOLEAN", false)
@@ -821,6 +845,9 @@ public class KintoneColumnVisitorTest {
         .setJson("JSON", ValueFactory.newString(""))
         .setJson("JSON|SUBTABLE", ValueFactory.newString(""))
         .setJson("JSON|SUBTABLE.SINGLE_LINE_TEXT", ValueFactory.newString(""))
+        .setJson("JSON|USER_SELECT", ValueFactory.newString(""))
+        .setJson("JSON|ORGANIZATION_SELECT", ValueFactory.newString(""))
+        .setJson("JSON|GROUP_SELECT", ValueFactory.newString(""))
         .addRecord()
         .setBoolean("BOOLEAN|SINGLE_LINE_TEXT", true)
         .setBoolean("BOOLEAN", true)

--- a/src/test/java/org/embulk/output/kintone/deserializer/DeserializerTest.java
+++ b/src/test/java/org/embulk/output/kintone/deserializer/DeserializerTest.java
@@ -37,8 +37,53 @@ import org.junit.Test;
 
 public class DeserializerTest {
   // spotless:off
-  public static final Function<Long, String> TABLE_ROW = (id) -> String.format("{\"id\":%d,\"value\":{\"リッチエディター\":{\"type\":\"RICH_TEXT\",\"value\":\"\\u003ca href\\u003d\\\"https://www.cybozu.com\\\"\\u003eサイボウズ\\u003c/a\\u003e\"},\"グループ選択\":{\"type\":\"GROUP_SELECT\",\"value\":[{\"name\":\"プロジェクトマネージャー\",\"code\":\"project_manager\"},{\"name\":\"チームリーダー\",\"code\":\"team_leader\"}]},\"文字列（1行）\":{\"type\":\"SINGLE_LINE_TEXT\",\"value\":\"テストです。\"},\"ラジオボタン\":{\"type\":\"RADIO_BUTTON\",\"value\":\"選択肢3\"},\"ドロップダウン\":{\"type\":\"DROP_DOWN\",\"value\":\"選択肢6\"},\"組織選択\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[{\"name\":\"開発部\",\"code\":\"kaihatsu\"},{\"name\":\"人事部\",\"code\":\"jinji\"}]},\"ユーザー選択\":{\"type\":\"USER_SELECT\",\"value\":[{\"name\":\"Noboru Sato\",\"code\":\"guest/sato@cybozu.com\"},{\"name\":\"Misaki Kato\",\"code\":\"kato\"}]},\"日時\":{\"type\":\"DATETIME\",\"value\":\"2012-01-11T11:30:00Z\"},\"文字列（複数行）\":{\"type\":\"MULTI_LINE_TEXT\",\"value\":\"テスト\\nです。\"},\"時刻\":{\"type\":\"TIME\",\"value\":\"11:30\"},\"チェックボックス\":{\"type\":\"CHECK_BOX\",\"value\":[\"選択肢1\",\"選択肢2\"]},\"複数選択\":{\"type\":\"MULTI_SELECT\",\"value\":[\"選択肢4\",\"選択肢5\"]},\"数値\":{\"type\":\"NUMBER\",\"value\":\"123\"},\"添付ファイル\":{\"type\":\"FILE\",\"value\":[{\"contentType\":\"text/plain\",\"fileKey\":\"201202061155587E339F9067544F1A92C743460E3D12B3297\",\"name\":\"17to20_VerupLog (1).txt\",\"size\":\"23175\"},{\"contentType\":\"application/json\",\"fileKey\":\"201202061155583C763E30196F419E83E91D2E4A03746C273\",\"name\":\"17to20_VerupLog.txt\",\"size\":\"23176\"}]},\"リンク\":{\"type\":\"LINK\",\"value\":\"https://cybozu.co.jp/\"},\"計算\":{\"type\":\"CALC\",\"value\":\"456\"},\"日付\":{\"type\":\"DATE\",\"value\":\"2012-01-11\"}}}", id);
-  private static final String NULL_TABLE_ROW = "{\"value\":{\"添付ファイル（null要素）\":{\"type\":\"FILE\",\"value\":[null,null]},\"添付ファイル（null項目）\":{\"type\":\"FILE\",\"value\":[{},{}]},\"複数選択（空）\":{\"type\":\"MULTI_SELECT\",\"value\":[]},\"リッチエディター\":{\"type\":\"RICH_TEXT\"},\"文字列（1行）\":{\"type\":\"SINGLE_LINE_TEXT\"},\"ユーザー選択（null項目）\":{\"type\":\"USER_SELECT\",\"value\":[{},{}]},\"文字列（複数行）\":{\"type\":\"MULTI_LINE_TEXT\"},\"ユーザー選択（空）\":{\"type\":\"USER_SELECT\",\"value\":[]},\"チェックボックス（null要素）\":{\"type\":\"CHECK_BOX\",\"value\":[null,null]},\"組織選択（null項目）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[{},{}]},\"計算\":{\"type\":\"CALC\"},\"日付\":{\"type\":\"DATE\"},\"組織選択（空）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[]},\"添付ファイル（空）\":{\"type\":\"FILE\",\"value\":[]},\"ラジオボタン\":{\"type\":\"RADIO_BUTTON\"},\"グループ選択（null項目）\":{\"type\":\"GROUP_SELECT\",\"value\":[{},{}]},\"複数選択（null要素）\":{\"type\":\"MULTI_SELECT\",\"value\":[null,null]},\"ドロップダウン\":{\"type\":\"DROP_DOWN\"},\"日時\":{\"type\":\"DATETIME\"},\"組織選択（null要素）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[null,null]},\"時刻\":{\"type\":\"TIME\"},\"グループ選択（空）\":{\"type\":\"GROUP_SELECT\",\"value\":[]},\"数値\":{\"type\":\"NUMBER\"},\"ユーザー選択（null要素）\":{\"type\":\"USER_SELECT\",\"value\":[null,null]},\"グループ選択（null要素）\":{\"type\":\"GROUP_SELECT\",\"value\":[null,null]},\"リンク\":{\"type\":\"LINK\"},\"チェックボックス（空）\":{\"type\":\"CHECK_BOX\",\"value\":[]}}}";
+  public static final Function<Long, String> TABLE_ROW = (id) -> String.format("{\"id\":%d,\"value\":{"
+      + "\"リッチエディター\":{\"type\":\"RICH_TEXT\",\"value\":\"\\u003ca href\\u003d\\\"https://www.cybozu.com\\\"\\u003eサイボウズ\\u003c/a\\u003e\"},"
+      + "\"グループ選択\":{\"type\":\"GROUP_SELECT\",\"value\":[{\"name\":\"プロジェクトマネージャー\",\"code\":\"project_manager\"},{\"name\":\"チームリーダー\",\"code\":\"team_leader\"}]},"
+      + "\"文字列（1行）\":{\"type\":\"SINGLE_LINE_TEXT\",\"value\":\"テストです。\"},"
+      + "\"ラジオボタン\":{\"type\":\"RADIO_BUTTON\",\"value\":\"選択肢3\"},"
+      + "\"ドロップダウン\":{\"type\":\"DROP_DOWN\",\"value\":\"選択肢6\"},"
+      + "\"組織選択\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[{\"name\":\"開発部\",\"code\":\"kaihatsu\"},{\"name\":\"人事部\",\"code\":\"jinji\"}]},"
+      + "\"ユーザー選択\":{\"type\":\"USER_SELECT\",\"value\":[{\"name\":\"Noboru Sato\",\"code\":\"guest/sato@cybozu.com\"},{\"name\":\"Misaki Kato\",\"code\":\"kato\"}]},"
+      + "\"ユーザー選択(コードのみ)\":{\"type\":\"USER_SELECT\",\"value\":[{\"code\":\"guest/sato@cybozu.com\"},{\"code\":\"kato\"}]},"
+      + "\"ユーザー選択(コード配列)\":{\"type\":\"USER_SELECT\",\"value\":[\"guest/sato@cybozu.com\",\"kato\"]},"
+      + "\"日時\":{\"type\":\"DATETIME\",\"value\":\"2012-01-11T11:30:00Z\"},"
+      + "\"文字列（複数行）\":{\"type\":\"MULTI_LINE_TEXT\",\"value\":\"テスト\\nです。\"},"
+      + "\"時刻\":{\"type\":\"TIME\",\"value\":\"11:30\"},"
+      + "\"チェックボックス\":{\"type\":\"CHECK_BOX\",\"value\":[\"選択肢1\",\"選択肢2\"]},"
+      + "\"複数選択\":{\"type\":\"MULTI_SELECT\",\"value\":[\"選択肢4\",\"選択肢5\"]},"
+      + "\"数値\":{\"type\":\"NUMBER\",\"value\":\"123\"},"
+      + "\"添付ファイル\":{\"type\":\"FILE\",\"value\":[{\"contentType\":\"text/plain\",\"fileKey\":\"201202061155587E339F9067544F1A92C743460E3D12B3297\",\"name\":\"17to20_VerupLog (1).txt\",\"size\":\"23175\"},{\"contentType\":\"application/json\",\"fileKey\":\"201202061155583C763E30196F419E83E91D2E4A03746C273\",\"name\":\"17to20_VerupLog.txt\",\"size\":\"23176\"}]},"
+      + "\"リンク\":{\"type\":\"LINK\",\"value\":\"https://cybozu.co.jp/\"},"
+      + "\"計算\":{\"type\":\"CALC\",\"value\":\"456\"},\"日付\":{\"type\":\"DATE\",\"value\":\"2012-01-11\"}}}",
+    id);
+  private static final String NULL_TABLE_ROW = "{\"value\":{"
+    + "\"添付ファイル（null要素）\":{\"type\":\"FILE\",\"value\":[null,null]},"
+    + "\"添付ファイル（null項目）\":{\"type\":\"FILE\",\"value\":[{},{}]},"
+    + "\"複数選択（空）\":{\"type\":\"MULTI_SELECT\",\"value\":[]},"
+    + "\"リッチエディター\":{\"type\":\"RICH_TEXT\"},"
+    + "\"文字列（1行）\":{\"type\":\"SINGLE_LINE_TEXT\"},"
+    + "\"ユーザー選択（null項目）\":{\"type\":\"USER_SELECT\",\"value\":[{},{}]},"
+    + "\"文字列（複数行）\":{\"type\":\"MULTI_LINE_TEXT\"},"
+    + "\"ユーザー選択（空）\":{\"type\":\"USER_SELECT\",\"value\":[]},"
+    + "\"チェックボックス（null要素）\":{\"type\":\"CHECK_BOX\",\"value\":[null,null]},"
+    + "\"組織選択（null項目）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[{},{}]},"
+    + "\"計算\":{\"type\":\"CALC\"},\"日付\":{\"type\":\"DATE\"},"
+    + "\"組織選択（空）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[]},"
+    + "\"添付ファイル（空）\":{\"type\":\"FILE\",\"value\":[]},"
+    + "\"ラジオボタン\":{\"type\":\"RADIO_BUTTON\"},"
+    + "\"グループ選択（null項目）\":{\"type\":\"GROUP_SELECT\",\"value\":[{},{}]}"
+    + ",\"複数選択（null要素）\":{\"type\":\"MULTI_SELECT\",\"value\":[null,null]},"
+    + "\"ドロップダウン\":{\"type\":\"DROP_DOWN\"},"
+    + "\"日時\":{\"type\":\"DATETIME\"},"
+    + "\"組織選択（null要素）\":{\"type\":\"ORGANIZATION_SELECT\",\"value\":[null,null]},"
+    + "\"時刻\":{\"type\":\"TIME\"},"
+    + "\"グループ選択（空）\":{\"type\":\"GROUP_SELECT\",\"value\":[]},"
+    + "\"数値\":{\"type\":\"NUMBER\"},"
+    + "\"ユーザー選択（null要素）\":{\"type\":\"USER_SELECT\",\"value\":[null,null]},"
+    + "\"グループ選択（null要素）\":{\"type\":\"GROUP_SELECT\",\"value\":[null,null]},"
+    + "\"リンク\":{\"type\":\"LINK\"},"
+    + "\"チェックボックス（空）\":{\"type\":\"CHECK_BOX\",\"value\":[]}}}";
   // spotless:on
   @Test
   public void deserialize() {
@@ -98,6 +143,8 @@ public class DeserializerTest {
     tableRow.putField("複数選択", new MultiSelectFieldValue("選択肢4", "選択肢5"));
     tableRow.putField("ドロップダウン", new DropDownFieldValue("選択肢6"));
     tableRow.putField("ユーザー選択", new UserSelectFieldValue(user("guest/sato@cybozu.com", "Noboru Sato"), user("kato", "Misaki Kato")));
+    tableRow.putField("ユーザー選択(コードのみ)", new UserSelectFieldValue(user("guest/sato@cybozu.com", null), user("kato", null)));
+    tableRow.putField("ユーザー選択(コード配列)", new UserSelectFieldValue(user("guest/sato@cybozu.com"), user("kato")));
     tableRow.putField("組織選択", new OrganizationSelectFieldValue(organization("kaihatsu", "開発部"), organization("jinji", "人事部")));
     tableRow.putField("グループ選択", new GroupSelectFieldValue(group("project_manager", "プロジェクトマネージャー"), group("team_leader", "チームリーダー")));
     tableRow.putField("日付", new DateFieldValue(LocalDate.parse("2012-01-11")));
@@ -140,6 +187,10 @@ public class DeserializerTest {
     tableRow.putField("添付ファイル（null項目）", new FileFieldValue(fileBody(null, null, null, null), fileBody(null, null, null, null)));
     // spotless:on
     return tableRow;
+  }
+
+  private static User user(String code) {
+    return new User(code);
   }
 
   private static User user(String code, String name) {


### PR DESCRIPTION
add to support USER_SELECT, ORGANIZATION_SELECT and GROUP_SELECT.

To select User (Organization, or Group), it needs only code, so this modification allows code string array.
And also, it supports an object like `{"code": "test"}`.
